### PR TITLE
Fix TailTypeFactory service access during class initialization

### DIFF
--- a/src/main/java/dev/xeonkryptos/xeonrobotframeworkplugin/psi/RobotKeywordProvider.java
+++ b/src/main/java/dev/xeonkryptos/xeonrobotframeworkplugin/psi/RobotKeywordProvider.java
@@ -1,7 +1,6 @@
 package dev.xeonkryptos.xeonrobotframeworkplugin.psi;
 
 import com.intellij.codeInsight.TailType;
-import com.intellij.codeInsight.TailTypes;
 import com.intellij.psi.tree.IElementType;
 import dev.xeonkryptos.xeonrobotframeworkplugin.util.RobotNames;
 import dev.xeonkryptos.xeonrobotframeworkplugin.util.RobotTailTypes;
@@ -101,11 +100,11 @@ public class RobotKeywordProvider {
         KEYWORD_TABLE.addSyntax(GHERKIN, "AND");
         KEYWORD_TABLE.addSyntax(GHERKIN, "BUT");
 
-        addRecommendation(GHERKIN, "GIVEN", "Given", TailTypes.spaceType());
-        addRecommendation(GHERKIN, "WHEN", "WHEN", TailTypes.spaceType());
-        addRecommendation(GHERKIN, "THEN", "THEN", TailTypes.spaceType());
-        addRecommendation(GHERKIN, "AND", "AND", TailTypes.spaceType());
-        addRecommendation(GHERKIN, "BUT", "BUT", TailTypes.spaceType());
+        addRecommendation(GHERKIN, "GIVEN", "Given", RobotTailTypes.SPACE);
+        addRecommendation(GHERKIN, "WHEN", "WHEN", RobotTailTypes.SPACE);
+        addRecommendation(GHERKIN, "THEN", "THEN", RobotTailTypes.SPACE);
+        addRecommendation(GHERKIN, "AND", "AND", RobotTailTypes.SPACE);
+        addRecommendation(GHERKIN, "BUT", "BUT", RobotTailTypes.SPACE);
 
         KEYWORD_TABLE.addSyntax(SYNTAX_MARKER, "IF");
         KEYWORD_TABLE.addSyntax(SYNTAX_MARKER, "END");
@@ -128,16 +127,16 @@ public class RobotKeywordProvider {
 
         addRecommendation(SYNTAX_MARKER, "IF", "IF", RobotTailTypes.TAB);
         addRecommendation(RobotTypes.CONDITIONAL_STRUCTURE, "ELSE IF", "ELSE IF", RobotTailTypes.TAB);
-        addRecommendation(RobotTypes.CONDITIONAL_STRUCTURE, "ELSE", "ELSE", TailTypes.noneType());
+        addRecommendation(RobotTypes.CONDITIONAL_STRUCTURE, "ELSE", "ELSE", RobotTailTypes.NONE);
         addRecommendation(SYNTAX_MARKER, "WHILE", "WHILE", RobotTailTypes.TAB);
         addRecommendation(SYNTAX_MARKER, "FOR", "FOR", RobotTailTypes.TAB);
-        addRecommendation(RobotTypes.LOOP_CONTROL_STRUCTURE, "CONTINUE", "CONTINUE", TailTypes.noneType());
-        addRecommendation(RobotTypes.LOOP_CONTROL_STRUCTURE, "BREAK", "BREAK", TailTypes.noneType());
-        addRecommendation(SYNTAX_MARKER, "TRY", "TRY", TailTypes.noneType());
+        addRecommendation(RobotTypes.LOOP_CONTROL_STRUCTURE, "CONTINUE", "CONTINUE", RobotTailTypes.NONE);
+        addRecommendation(RobotTypes.LOOP_CONTROL_STRUCTURE, "BREAK", "BREAK", RobotTailTypes.NONE);
+        addRecommendation(SYNTAX_MARKER, "TRY", "TRY", RobotTailTypes.NONE);
         addRecommendation(RobotTypes.EXCEPTION_HANDLING_STRUCTURE, "EXCEPT", "EXCEPT", RobotTailTypes.TAB);
-        addRecommendation(RobotTypes.EXCEPTION_HANDLING_STRUCTURE, "ELSE", "ELSE", TailTypes.noneType());
-        addRecommendation(RobotTypes.EXCEPTION_HANDLING_STRUCTURE, "FINALLY", "FINALLY", TailTypes.noneType());
-        addRecommendation(RobotTypes.USER_KEYWORD_STATEMENT, "RETURN", "RETURN", TailTypes.noneType());
+        addRecommendation(RobotTypes.EXCEPTION_HANDLING_STRUCTURE, "ELSE", "ELSE", RobotTailTypes.NONE);
+        addRecommendation(RobotTypes.EXCEPTION_HANDLING_STRUCTURE, "FINALLY", "FINALLY", RobotTailTypes.NONE);
+        addRecommendation(RobotTypes.USER_KEYWORD_STATEMENT, "RETURN", "RETURN", RobotTailTypes.NONE);
         addRecommendation(RobotTypes.FOR_IN, "IN", "IN", RobotTailTypes.TAB);
         addRecommendation(RobotTypes.FOR_IN, "IN RANGE", "IN RANGE", RobotTailTypes.TAB);
         addRecommendation(RobotTypes.FOR_IN, "IN ENUMERATE", "IN ENUMERATE", RobotTailTypes.TAB);

--- a/src/main/java/dev/xeonkryptos/xeonrobotframeworkplugin/util/RobotTailTypes.java
+++ b/src/main/java/dev/xeonkryptos/xeonrobotframeworkplugin/util/RobotTailTypes.java
@@ -14,4 +14,11 @@ public final class RobotTailTypes {
       }
    };
    public static final TailType ASSIGNMENT_TAIL_TYPE = TailType.createSimpleTailType('=');
+   public static final TailType SPACE = TailType.createSimpleTailType(' ');
+   public static final TailType NONE = new TailType() {
+      @Override
+      public int processTail(Editor editor, int tailOffset) {
+         return tailOffset;
+      }
+   };
 }


### PR DESCRIPTION
## Problem

Code completion in Robot files crashes on newer IntelliJ platforms:

```
dev.xeonkryptos.xeonrobotframeworkplugin.psi.RobotKeywordProvider <clinit>
requests com.intellij.codeInsight.TailTypeFactory instance. Class
initialization must not depend on services. Consider using instance of the
service on-demand instead.
```

`RobotKeywordProvider`'s static initializer calls `TailTypes.spaceType()` and
`TailTypes.noneType()`, both of which look up the `TailTypeFactory` service.
Recent platform versions forbid service access during class initialization, so
instantiating `RobotCompletionContributor` (which references the provider) throws.

## Fix

Add service-free equivalents to `RobotTailTypes` and use them instead:

- `SPACE` — `TailType.createSimpleTailType(' ')` (same approach already used for `NEW_LINE`)
- `NONE` — a no-op `TailType` returning `tailOffset` unchanged

No service lookup happens in `<clinit>` anymore.

## Testing

- `./gradlew compileJava --rerun-tasks` — clean
- `./gradlew runIde` — sandbox IDE boots and completion in `.robot` files works,
  no `TailTypeFactory` error in the log